### PR TITLE
redefine node support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
           - ubuntu-latest
           # - macos-latest
           # - windows-latest
-        node_version: [6.x, 8.x, 10.x, 12.x, 14.x, 15.x]
+        node_version: [14.x, 16.x, 18.x, 19.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -108,6 +108,6 @@
   },
   "engineStrict": true,
   "engines": {
-    "node": ">= 6.10.0"
+    "node": "14.x || 16.x || 18.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -108,6 +108,6 @@
   },
   "engineStrict": true,
   "engines": {
-    "node": "14.x || 16.x || 18.x"
+    "node": "14.x || 16.x || 18.x || 19.x"
   }
 }


### PR DESCRIPTION
do not support end-of-life node versions.

support only LTS releases and single latest unstable release

https://github.com/nodejs/release