### PR TITLE
fix: fixing unhandled exception when fetching settings file

### DIFF
--- a/lib/utils/SettingsFileUtil.js
+++ b/lib/utils/SettingsFileUtil.js
@@ -70,9 +70,16 @@ let SettingsFileUtil = {
           options.port = port;
         }
 
-        (protocol === 'https' ? https : http).get(options, res => {
-          SettingsFileUtil.handleHttpRequest(res, resolve, reject);
-        });
+        (protocol === 'https' ? https : http)
+          .get(options, res => {
+            SettingsFileUtil.handleHttpRequest(res, resolve, reject);
+          })
+          .on('error', err => {
+            console.error(
+              `VWO-SDK - [ERROR]: ${getCurrentTime()} https.get failed for fetching account settings - ${err.message}`
+            );
+            reject(err);
+          });
       });
     }
   },


### PR DESCRIPTION
We are seeing several server crashes caused by VWO SDK throwing unhandled exception.  
Turned out the http(s).get doesn't have `on("error")` handler attached, which causes node crash if any HTTP(S) errors happen.