### PR TITLE
Fix POST calls for Edge runtime and FetchUtil formatting/parsing

### DIFF
--- a/lib/utils/EventDispatcherUtil.js
+++ b/lib/utils/EventDispatcherUtil.js
@@ -110,7 +110,7 @@ let EventDispatcher = {
 
       if (typeof process.env === 'undefined') {
         if (typeof XMLHttpRequest === 'undefined') {
-          require('./FetchUtil')
+          return require('./FetchUtil')
             .send({
               method: 'POST',
               url: `${properties.url}${queryParams}`,
@@ -128,7 +128,7 @@ let EventDispatcher = {
             });
         }
 
-        require('./XhrUtil')
+        return require('./XhrUtil')
           .send({
             method: 'POST',
             url: `${properties.url}${queryParams}`,
@@ -149,8 +149,11 @@ let EventDispatcher = {
 
         parsedUrl = url.parse(properties.url);
 
-        require('./HttpHandlerUtil').sendPostCall(parsedUrl, payload, queryParams, null, error => {
-          this.handlePostResponse(properties, payload, error);
+        return new Promise(resolve => {
+          require('./HttpHandlerUtil').sendPostCall(parsedUrl, payload, queryParams, null, error => {
+            const result = this.handlePostResponse(properties, payload, error);
+            resolve(result);
+          });
         });
       }
     } catch (err) {
@@ -166,7 +169,7 @@ let EventDispatcher = {
       );
     }
 
-    return false;
+    return Promise.resolve(false);
   },
 
   handlePostResponse: function(properties, payload, error) {

--- a/lib/utils/FetchUtil.js
+++ b/lib/utils/FetchUtil.js
@@ -72,28 +72,37 @@ const FetchUtil = {
         };
 
         if (method === 'POST') {
-          options.body = payload;
+          options.body = JSON.stringify(payload);
         }
 
         return fetch(url, options)
           .then(res => {
-            const jsonData = res.json();
+            // Some endpoints return empty strings as the response body; treat
+            // as raw text and handle potential JSON parsing errors below
+            return res.text().then(text => {
+              let jsonData = {};
+              try {
+                jsonData = JSON.parse(text);
+              } catch (err) {
+                console.error(`VWO-SDK - [ERROR]: ${getCurrentTime()} Error parsing JSON response: ${err}`);
+              }
 
-            if (userStorageService && isObject(userStorageService) && isFunction(userStorageService.setSettings)) {
-              userStorageService.setSettings(jsonData);
-            }
+              if (userStorageService && isObject(userStorageService) && isFunction(userStorageService.setSettings)) {
+                userStorageService.setSettings(jsonData);
+              }
 
-            console.log(res.status);
-            if (res.status === 200) {
-              resolve(jsonData);
-            } else {
-              let error = `VWO-SDK - [ERROR]: ${getCurrentTime()} Request failed for fetching account settings. Got Status Code: ${
-                res.status
-              }`;
+              console.log(res.status);
+              if (res.status === 200) {
+                resolve(jsonData);
+              } else {
+                let error = `VWO-SDK - [ERROR]: ${getCurrentTime()} Request failed for fetching account settings. Got Status Code: ${
+                  res.status
+                }`;
 
-              console.error(error);
-              reject(error);
-            }
+                console.error(error);
+                reject(error);
+              }
+            });
           })
           .catch(err => {
             let error = `VWO-SDK - [ERROR]: ${getCurrentTime()} Request failed for fetching account settings. Got Status Code: ${err}`;


### PR DESCRIPTION
Implements fixes so that Impression events succeed when using the library with Next.js middleware on Vercel.

## Fixes to `dispatchPostCall()` in `EventDispatcherUtil`:

The block within the `if (typeof process.env === 'undefined')` normally executes in a browser environment and skips using `FetchUtil` since `XMLHttpRequest` is available. However, the block also executes in Edge environments where `XMLHttpRequest` is **not** available (the browser bundle has `process.env` permanently replaced during build so that the block always runs, and Next.js loads the browser bundle for middleware). It seems the intention was to use `FetchUtil` *instead of* `XhrUtil` in this situation, but missing `return` statements were causing both to be called at once, resulting in these 2 errors on the same page load:

![Screenshot 2023-05-02 145208](https://user-images.githubusercontent.com/36826301/235758875-dbca4fcb-03d5-46a1-b60e-a43e1f31a611.png)

The 2nd error circled is specific to `FetchUtil` – more on that below...

## Fixes to `FetchUtil`:

- `POST` requests were incorrectly using the raw `payload` object as the body instead of converting it to a JSON string. The API was still returning a successful 200 response for some reason, but Impression events were silently failing to track in VWO. After fixing this to convert the body to JSON, I was able to see Impression events incrementing again in my account dashboard. There doesn't seem to be any better way to test/verify this at the moment.

- `res.json()` was failing for Impression events because the API endpoint seems to always return an empty string for the body (see 2nd error in screenshot above). This was happening even with successful requests that included the fix above. I fixed this to add error handling around the response JSON parsing and simply log parsing errors to the console. This allows the remaining logic to execute without being interrupted by the `.catch()` below.